### PR TITLE
Fix namespace bar in alert-details component

### DIFF
--- a/frontend/src/app/alerts/components/alert-details/alert-details.component.html
+++ b/frontend/src/app/alerts/components/alert-details/alert-details.component.html
@@ -144,6 +144,7 @@
                                 <query-editor-proto [label]="'Q' + (index + 1)" [query]="query" [queries]="queries"
                                     [widget]="{queries: queries}"
                                     [options]="{
+                                        enableNamespace: enableNamespace,
                                         metaSource: data.type === 'healthcheck' ? 'aurastatus:check' : 'meta',
                                         enableMultipleQueries: data.type === 'simple',
                                         enableMetric: data.type === 'simple',

--- a/frontend/src/app/alerts/components/alert-details/alert-details.component.ts
+++ b/frontend/src/app/alerts/components/alert-details/alert-details.component.ts
@@ -198,6 +198,7 @@ export class AlertDetailsComponent implements OnInit, OnDestroy, AfterContentIni
         { label: 'P5', value: 'P5' }
     ];
 
+    enableNamespace = true;
     defaultNamespace = '';
     defaultOpsGeniePriority = 'P5';
     defaultOCSeverity = '5';
@@ -348,8 +349,10 @@ export class AlertDetailsComponent implements OnInit, OnDestroy, AfterContentIni
     }
 
     ngOnInit() {
+        const config = this.appConfig.getConfig();
         this.alertspageNavbarPortal = new TemplatePortal(this.alertDateTimeNavbarItemTmpl, undefined, {});
         this.cdkService.setNavbarPortal(this.alertspageNavbarPortal);
+        this.enableNamespace = config.namespace && config.namespace.enabled !== undefined ? config.namespace.enabled : true;
         this.defaultNamespace = this.appConfig.getDefaultNamespace();
 
         this.subscription.add(this.themeService.getThemeType().subscribe( themeType => {


### PR DESCRIPTION
When namespace is enabled, the namespace toggle is not displayed in the alert edit screen.