### PR TITLE
Bugs/jira 14168 - copy Widget error fix

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,7 @@
     "d3-format": "1.4.1",
     "d3-scale-chromatic": "^2.0.0",
     "date-fns": "^1.29.0",
-    "dom-to-image-more": "^2.8.0",
+    "dom-to-image-more": "2.8.0",
     "dygraphs": "^2.1.0",
     "fast-deep-equal": "^2.0.1",
     "hammerjs": "^2.0.8",


### PR DESCRIPTION
Was a dependency version issue. Locked dependency to working version when developed