### PR TITLE
Changeable to strat server by ssl or non ssl.

### DIFF
--- a/server/bin/www
+++ b/server/bin/www
@@ -3,33 +3,44 @@
 /**
  * Module dependencies.
  */
+
 var app = require('../index');
 var debug = require('debug')('server:server');
 var path = require('path');
 var port;
 var server;
 
-if(process.env.SSL_CERTIFICATE_PATH &&
-    process.env.SSL_PRIVATE_KEY_PATH
-){
+var enableTls = process.env.USE_TLS || 'true';
+var sslPath = '.ssh/opentsdb/';
+
+if(JSON.parse(enableTls.toLowerCase())){
   var https = require('https');
   var fs = require('fs');
-  port = process.env.PORT || 4443;
+  
   /**
    * Get port from environment and store in Express.
    * */
-  var privateKey = fs.readFileSync(path.resolve(process.env.SSL_PRIVATE_KEY_PATH), 'utf8');
-  var certificate = fs.readFileSync(path.resolve(process.env.SSL_CERTIFICATE_PATH), 'utf8');
-  var credentials = { key: privateKey, cert: certificate };
+  port = process.env.PORT || 4443;
   app.set('port', port);
+  
   /**
    * Create HTTPS server.
    */
+  var privateKey = fs.readFileSync(path.resolve(process.env.HOME, sslPath, 'dev.opentsdb.key'), 'utf8');
+  var certificate = fs.readFileSync(path.resolve(process.env.HOME, sslPath, 'dev.opentsdb.crt'), 'utf8');
+
+  var credentials = { key: privateKey, cert: certificate };
+  
   server = https.createServer(credentials, app);
 }else{
   var http = require('http');
+  
+  /**
+   * Get port from environment and store in Express.
+   * */
   port = process.env.PORT || 4080;
   app.set('port', port);
+  
   /**
    * Create HTTP server.
    */

--- a/server/bin/www
+++ b/server/bin/www
@@ -7,20 +7,19 @@
 var app = require('../index');
 var debug = require('debug')('server:server');
 var path = require('path');
-var port;
+var port = process.env.PORT || 4443;
 var server;
 
 var enableTls = process.env.USE_TLS || 'true';
 var sslPath = '.ssh/opentsdb/';
 
-if(JSON.parse(enableTls.toLowerCase())){
+if(enableTls === 'true'){
   var https = require('https');
   var fs = require('fs');
   
   /**
    * Get port from environment and store in Express.
    * */
-  port = process.env.PORT || 4443;
   app.set('port', port);
   
   /**
@@ -38,7 +37,6 @@ if(JSON.parse(enableTls.toLowerCase())){
   /**
    * Get port from environment and store in Express.
    * */
-  port = process.env.PORT || 4080;
   app.set('port', port);
   
   /**

--- a/server/bin/www
+++ b/server/bin/www
@@ -3,31 +3,38 @@
 /**
  * Module dependencies.
  */
-
 var app = require('../index');
 var debug = require('debug')('server:server');
-var https = require('https');
-var fs = require('fs');
 var path = require('path');
+var port;
+var server;
 
-var sslPath = '.ssh/opentsdb/';
-
-/**
- * Get port from environment and store in Express.
- */
-var port = 4443;
-app.set('port', port);
-
-/**
- * Create HTTP server.
- */
-
-var privateKey = fs.readFileSync(path.resolve(process.env.HOME, sslPath, 'dev.opentsdb.key'), 'utf8');
-var certificate = fs.readFileSync(path.resolve(process.env.HOME, sslPath, 'dev.opentsdb.crt'), 'utf8');
-
-var credentials = { key: privateKey, cert: certificate };
-
-var server = https.createServer(credentials, app);
+if(process.env.SSL_CERTIFICATE_PATH &&
+    process.env.SSL_PRIVATE_KEY_PATH
+){
+  var https = require('https');
+  var fs = require('fs');
+  port = process.env.PORT || 4443;
+  /**
+   * Get port from environment and store in Express.
+   * */
+  var privateKey = fs.readFileSync(path.resolve(process.env.SSL_PRIVATE_KEY_PATH), 'utf8');
+  var certificate = fs.readFileSync(path.resolve(process.env.SSL_CERTIFICATE_PATH), 'utf8');
+  var credentials = { key: privateKey, cert: certificate };
+  app.set('port', port);
+  /**
+   * Create HTTPS server.
+   */
+  server = https.createServer(credentials, app);
+}else{
+  var http = require('http');
+  port = process.env.PORT || 4080;
+  app.set('port', port);
+  /**
+   * Create HTTP server.
+   */
+  server = http.createServer(app);
+}
 
 /**
  * Listen on provided port, on all network interfaces.


### PR DESCRIPTION
Hi there,

I hope to deploy a Horizon using third party proxy that provides TLS termination.
So, I changed SSL or Non SSL is choosable that start a server by the environment variable.
Please check my PR.

Thanks.

**Usage**
Start app by SSL
`$ cd ./server`
`$ SSL_CERTIFICATE_PATH=~/.ssh/opentsdb/dev.opentsdb.crt SSL_PRIVATE_KEY_PATH=~/.ssh/opentsdb/dev.opentsdb.key PORT=443 npm start`

Start app by non SSL
`$ cd ./server`
`$ PORT=80 npm start`