### PR TITLE
Make query-download examples configurable

### DIFF
--- a/frontend/src/app/dashboard/containers/dashboard/dashboard.component.ts
+++ b/frontend/src/app/dashboard/containers/dashboard/dashboard.component.ts
@@ -2006,14 +2006,25 @@ export class DashboardComponent implements OnInit, OnDestroy {
         }
     }
 
+    buildDownloadQueryHelpString() {
+        const tsdb_host = this.appConfig.getConfig().tsdb_host
+        let msg = 'API URL: ' + tsdb_host + '/api/query/graph\n\n' +
+                  'HEADER:\n' +
+                  'Content-Type: application/json\n\n';
+
+        const examples = this.appConfig.getConfig().widget.downloadQuery.examples
+        for(let i = 0; i < examples.length; ++i) {
+            msg += examples[i] + '\n\n';
+        }
+
+        return msg;
+    }
+
     downloadDataQuery(message) {
         const ts = new Date().getTime();
         const query = this.getQuery(message);
         const wd = message.payload;
-        const data = 'API URL: https://metrics.yamas.ouroath.com:443/api/query/graph\n\n' +
-                    'HEADER:\n' +
-                    'Content-Type: application/json\n\n' +
-                    'CURL: curl -ki --cert /var/lib/sia/certs/<CERT>.cert.pem --key /var/lib/sia/keys/<KEY>.key.pem -X POST -d@<QUERY>.json -H \'Content-Type: application/json\' \'https://metrics.yamas.ouroath.com/api/query/graph\'\n\n' +
+        const data = buildDownloadQueryHelpString() +
                     'QUERY:\n' + JSON.stringify(query);
 
         const file = new Blob([data], {type: 'text/text'});

--- a/frontend/src/app/dashboard/containers/dashboard/dashboard.component.ts
+++ b/frontend/src/app/dashboard/containers/dashboard/dashboard.component.ts
@@ -2007,12 +2007,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
 
     buildDownloadQueryHelpString() {
-        const tsdb_host = this.appConfig.getConfig().tsdb_host
+        const tsdb_host = this.appConfig.getConfig().tsdb_host;
         let msg = 'API URL: ' + tsdb_host + '/api/query/graph\n\n' +
                   'HEADER:\n' +
                   'Content-Type: application/json\n\n';
 
-        const examples = this.appConfig.getConfig().widget.downloadQuery.examples
+        const examples = this.appConfig.getConfig().widget.downloadQuery.examples;
         for(let i = 0; i < examples.length; ++i) {
             msg += examples[i] + '\n\n';
         }

--- a/frontend/src/app/dashboard/containers/dashboard/dashboard.component.ts
+++ b/frontend/src/app/dashboard/containers/dashboard/dashboard.component.ts
@@ -2024,7 +2024,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
         const ts = new Date().getTime();
         const query = this.getQuery(message);
         const wd = message.payload;
-        const data = buildDownloadQueryHelpString() +
+        const data = this.buildDownloadQueryHelpString() +
                     'QUERY:\n' + JSON.stringify(query);
 
         const file = new Blob([data], {type: 'text/text'});

--- a/server/config/app_config.json
+++ b/server/config/app_config.json
@@ -44,6 +44,14 @@
         }
       }
     },
+    "widget": {
+        "downloadQuery": {
+            "examples": [
+                "<% query example 1 (curl?) %>",
+                "<% query example 2 (CLI?) %>"
+            ],
+        },
+    },
     "alert_history_url": "<% alert log history url %>",
     "helpLinks": [
         { "label": "User guide", "href": "#" },


### PR DESCRIPTION
This lets me add an example for our CLI, which is still internal-only.