### PR TITLE
Skip the namespace check in the group by tag key lookup as the no-nam…

### DIFF
--- a/frontend/src/app/shared/modules/sharedcomponents/components/dropdown-metric-tags/dropdown-metric-tags.component.ts
+++ b/frontend/src/app/shared/modules/sharedcomponents/components/dropdown-metric-tags/dropdown-metric-tags.component.ts
@@ -100,7 +100,7 @@ export class DropdownMetricTagsComponent implements OnInit, OnChanges {
             this.filteredTagOptions = this.tagOptions;
             this.triggerMenu();
         } else if (load ) {
-            if ( !this.namespace || !this.metric ) {
+            if ( !this.metric ) {
                 this.tagOptions = [];
                 this.filteredTagOptions = this.tagOptions;
                 this.triggerMenu();


### PR DESCRIPTION
…espace mode doesn't have a value there.