### PR TITLE
Fixing the Auto Refresh Issue on Alert Detail page

### DIFF
--- a/frontend/src/app/alerts/components/alert-details/alert-details.component.ts
+++ b/frontend/src/app/alerts/components/alert-details/alert-details.component.ts
@@ -289,7 +289,7 @@ export class AlertDetailsComponent implements OnInit, OnDestroy, AfterContentIni
     startTime;
     endTime;
     timeZone = 'local';
-    autoRefresh = {'auto': 0, 'duration': 60 };
+    autoRefresh = {'auto': 0, 'duration': 0 };
     prevTimeSampler = null;
     downsample = { aggregators: [''], customUnit: '', customValue: '', value: 'auto'};
     prevDateRange: any = null;


### PR DESCRIPTION
`frontend/src/app/alerts/components/alert-details/alert-details.component.ts`
The above file contains the following line, which was causing Alert Detail page to auto refresh, without user explicitly pressing auto refresh button. In addition auto refresh button indicates to users that auto refresh is turned off.
`autoRefresh = {'auto': 0, 'duration': 60 };`

Specifically this is caused by the following file's `ngOnChange` function:
`frontend/src/app/shared/modules/date-time-picker/components/time-picker/time-picker.component.ts`
```
    ngOnChanges(changes: SimpleChanges) {
        if ( changes.refresh !== undefined ) {
            const refresh = changes.refresh.currentValue;
            if ( refresh && refresh.duration ) {
                this.subscribeToAutoRefresh(refresh.duration);
            } else if ( this.refreshSubcription ) {
                this.refreshSubcription.unsubscribe();
            }
        }
        if ( this.refresh && this.refresh.duration && (changes.startTime !== undefined || changes.endTime !== undefined) ) {
            this.subscribeToAutoRefresh(this.isRelativeTime() ? this.refresh.duration : 0);
        }
        if ( changes.isEditMode !== undefined ) {
            this.paused$.next(changes.isEditMode.currentValue);
        }
    }
```
When alert detail page is first loaded and `ngOnChanges` is called, it will always invoke `this.subscribeToAutoRefresh(refresh.duration);` since changes.refresh.currentValue.duration will be 60.
This will initiate the autoRefresh despite user not explicitly pressing auto refresh button and button showing that it is currently off.

Changing the initial duration to 0 fixes this issue.
