### PR TITLE
versionup concurrently due to vulnerability

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,6 @@
     "express": "~4.17.0",
     "http-errors": "~1.6.2",
     "morgan": "~1.9.0",
-    "concurrently": "^4.1.0"
+    "concurrently": "^7.2.1"
   }
 }


### PR DESCRIPTION
In the server directory, `concurrently` library has been upgraded due to the following vulnerability

```
$ cd server
$ npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
# Run  npm install --save-dev concurrently@7.2.1  to resolve 1 vulnerability
SEMVER WARNING: Recommended action is a potentially breaking change
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Prototype Pollution in yargs-parser                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ yargs-parser                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ concurrently [dev]                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ concurrently > yargs > yargs-parser                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-p9pc-299p-vxgp            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```
----------
We have confirmed that the vulnerability is gone after the upgrade.
```
$ npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
found 0 vulnerabilitiesin 95 scanned packages
```