### PR TITLE
Configure webui endpoint

### DIFF
--- a/frontend/src/app/admin/components/admin-config/admin-config.component.html
+++ b/frontend/src/app/admin/components/admin-config/admin-config.component.html
@@ -55,6 +55,9 @@
                         </div>
                     </div>
                 </div>
+                <app-admin-config-generic-input class="form-group webui-host"
+                    inputLabel="WebUI Host"
+                    formControlName="webUI"></app-admin-config-generic-input>
                 <app-admin-config-generic-input class="form-group configdb-host"
                     inputLabel="ConfigDB Host"
                     formControlName="configdb"></app-admin-config-generic-input>

--- a/frontend/src/app/admin/components/admin-config/admin-config.component.ts
+++ b/frontend/src/app/admin/components/admin-config/admin-config.component.ts
@@ -87,6 +87,7 @@ export class AdminConfigComponent implements OnInit, OnDestroy {
         let endpoints = this.fb.group({
             tsdb_host: this.configValues.tsdb_host || '',
             tsdb_hosts: new FormArray([]),
+            webUI: this.configValues.webUI || '',
             configdb: this.configValues.configdb || '',
             metaApi: this.configValues.metaApi || '',
             auraUI: this.configValues.auraUI || ''

--- a/frontend/src/app/alerts/containers/alerts.component.ts
+++ b/frontend/src/app/alerts/containers/alerts.component.ts
@@ -278,6 +278,7 @@ export class AlertsComponent implements OnInit, OnDestroy, AfterViewChecked {
     // eslint-disable-next-line @typescript-eslint/no-inferrable-types
     namespaceDropMenuOpen: boolean = false;
     configLoaded$ = new Subject();
+    webUrl = '';
     auraUrl = '';
 
     error: any = false;
@@ -355,7 +356,7 @@ export class AlertsComponent implements OnInit, OnDestroy, AfterViewChecked {
     }
 
     ngOnInit() {
-
+        this.webUrl = this.appConfig.getConfig().webUI;
         this.urlOverrideService.initialize();
         this.auraUrl = this.appConfig.getConfig().auraUI + '/#/aura/newquery';
         this.alertSearch = new FormControl();
@@ -1089,7 +1090,7 @@ export class AlertsComponent implements OnInit, OnDestroy, AfterViewChecked {
             name: 'Alert from widget ' + payload.widget.settings.title,
             queries: {},
             notification: {
-                body: 'Created from dashboard: ' + 'https://yamas.ouroath.com/d/' + payload.dashboardId
+                body: 'Created from dashboard: ' + this.webUrl + '/d/' + payload.dashboardId
             },
             createdFrom: {
                 dashboardId: payload.dashboardId,

--- a/frontend/src/app/core/services/config.service.ts
+++ b/frontend/src/app/core/services/config.service.ts
@@ -37,6 +37,9 @@ export class AppConfigService {
           if ( !data.tsdb_host && ( !data.tsdb_hosts || !data.tsdb_hosts.length ) ) {
             this.errors.push("TSDB endpoint is invalid");
           }
+          if ( !data.webUI ) {
+            this.errors.push("Web UI endpoint is invalid");
+          }
           if ( !data.configdb ) {
             this.errors.push("Configdb endpoint is invalid");
           }

--- a/server/config/app_config.json
+++ b/server/config/app_config.json
@@ -18,6 +18,7 @@
         "<%tsdb endpoint b%>",
         "<%tsdb endpoint c%>"
     ],
+    "webUI": "<% webui endpoint %>",
     "configdb": "<% configdb endpoint %>",
     "metaApi": "<% meta endpoint %>",
     "auraUI": "<% Aura UI endpoint %>",


### PR DESCRIPTION
### Issue.
When I create an alert rule from a widget, the URL in the message field is always the domain of "https://yamas.ouroath.com". 

This is because the endpoint is hard coded.
https://github.com/OpenTSDB/opentsdb-horizon/blob/a20d70ffd4a47fbe91a9e5a7ad7f22b1b4b42943/frontend/src/app/alerts/containers/alerts.component.ts#L1092

### Fix
Implemented to set the webUI endpoint in app_config.json.