### PR TITLE
Fix UI bug in sum/avg of sliding window

### DIFF
--- a/frontend/src/app/alerts/components/alert-details/alert-details.component.ts
+++ b/frontend/src/app/alerts/components/alert-details/alert-details.component.ts
@@ -1330,8 +1330,10 @@ export class AlertDetailsComponent implements OnInit, OnDestroy, AfterContentIni
             const query: any = JSON.parse(JSON.stringify(this.queries[i]));
             if ( fx ) {
                 for ( let j =0; j < query.metrics.length; j++ ) {
-                    query.metrics[j].functions = query.metrics[j].functions || [];
-                    query.metrics[j].functions.push(fx);
+                    if ( query.metrics[j].id === this.thresholdSingleMetricControls.metricId.value ) {
+                        query.metrics[j].functions = query.metrics[j].functions || [];
+                        query.metrics[j].functions.push(fx);
+                    }
                 }
             }
             if (query.namespace && query.metrics.length) {


### PR DESCRIPTION
There is a bug in Alert Details that when sum or avg is used in the sliding window and expression is specified as Condition, a graph with sum or avg applied multiple times is displayed.
For example, this bug occurs when m1 is referenced in e1 and e1 is specified as Condition.
There was a problem with calculating e1 using m1 with sum or avg applied, so we fixed it so that it is applied only to the target specified in Condition.
Also, this change makes it so that the sliding window setting is not applied when "None" is specified for Condition.