### PR TITLE
Add configurable maxGraphs for multigraph

### DIFF
--- a/frontend/src/app/shared/modules/dynamic-widgets/components/linechart-widget/linechart-widget.component.ts
+++ b/frontend/src/app/shared/modules/dynamic-widgets/components/linechart-widget/linechart-widget.component.ts
@@ -424,7 +424,7 @@ export class LinechartWidgetComponent implements OnInit, AfterViewInit, OnDestro
                                 // fill out tag values from rawdata
                                 let results = this.multiService.fillMultiTagValues(this.widget, this.multiConf, rawdata);
                                 results = this.multiService.removeEmptyRowsColumns(results);
-                                const maxGraphs = 100;
+                                const maxGraphs = this.appConfig.getConfig().widget.multigraph.defaultMaxGraphs;
                                 const rowKeys = this.getGraphDataObjectKeys(results);
                                 const colKeys = rowKeys.length ? this.getGraphDataObjectKeys(results[rowKeys[0]]) : [];
                                 const maxCols = colKeys.length <= maxGraphs ? colKeys.length : maxGraphs;

--- a/server/config/app_config.json
+++ b/server/config/app_config.json
@@ -55,6 +55,9 @@
                 "<% query example 1 (curl?) %>",
                 "<% query example 2 (CLI?) %>"
             ]
+        },
+        "multigraph": {
+            "defaultMaxGraphs": 100
         }
     },
     "alert_history_url": "<% alert log history url %>",


### PR DESCRIPTION
We have in-house use cases that require specific multigraph widgets to display more than the 100-graph hardcoded limit. For example, one user wants 475 graphs in a single multigraph line-chart widget.

This PR simply turns the hardcoded global limit into a configurable global limit.

Later, we may want to allow users to specify higher limits on a per-widget basis.